### PR TITLE
chore: Finalize 26.2

### DIFF
--- a/src/client/java/com/mndk/bteterrarenderer/mcconnector/client/ClientMinecraftManagerImpl.java
+++ b/src/client/java/com/mndk/bteterrarenderer/mcconnector/client/ClientMinecraftManagerImpl.java
@@ -70,11 +70,11 @@ public class ClientMinecraftManagerImpl extends ClientMinecraftManager {
 
     @Override
     public void displayGuiScreen(@Nullable AbstractGuiScreenCopy screen) {
-//? if >=26.2-alpha.1 {
-        /*Minecraft.getInstance().gui.setScreen(screen == null ? null : new AbstractGuiScreenImpl(screen));
-*///? } else {
-        Minecraft.getInstance().setScreen(screen == null ? null : new AbstractGuiScreenImpl(screen));
-//? }
+//? if >=26.2 {
+        Minecraft.getInstance().gui.setScreen(screen == null ? null : new AbstractGuiScreenImpl(screen));
+//? } else {
+        /*Minecraft.getInstance().setScreen(screen == null ? null : new AbstractGuiScreenImpl(screen));
+*///? }
     }
 
     @Override
@@ -112,11 +112,11 @@ public class ClientMinecraftManagerImpl extends ClientMinecraftManager {
 
     @Override
     public void sendTextComponentToChat(TextWrapper textComponent) {
-//? if >=26.2-alpha.1 {
-        /*Minecraft.getInstance().gui.chatListener().handleSystemMessage(((TextWrapperImpl) textComponent).delegate, false);
-*///? } else if >=26.1 {
-        Minecraft.getInstance().getChatListener().handleSystemMessage(((TextWrapperImpl) textComponent).delegate, false); // Present since 1.20
-//? } else {
+//? if >=26.2 {
+        Minecraft.getInstance().gui.chatListener().handleSystemMessage(((TextWrapperImpl) textComponent).delegate, false);
+//? } else if >=26.1 {
+        /*Minecraft.getInstance().getChatListener().handleSystemMessage(((TextWrapperImpl) textComponent).delegate, false); // Present since 1.20
+*///? } else {
         /*LocalPlayer player = Minecraft.getInstance().player;
         if (player == null) return;
 

--- a/src/client/java/com/mndk/bteterrarenderer/mcconnector/client/graphics/BufferBuildersManagerImpl.java
+++ b/src/client/java/com/mndk/bteterrarenderer/mcconnector/client/graphics/BufferBuildersManagerImpl.java
@@ -43,19 +43,19 @@ public class BufferBuildersManagerImpl implements BufferBuildersManager {
                 .createRenderSetup();
     }
 
-    private static final BiFunction</*? if >=26.2-alpha.1 {*//*PrimitiveTopology*//*? } else {*/VertexFormat.Mode/*? }*/, Boolean, RenderPipeline> PIPELINE = Util.memoize(
+    private static final BiFunction</*? if >=26.2 {*/PrimitiveTopology/*? } else {*//*VertexFormat.Mode*//*? }*/, Boolean, RenderPipeline> PIPELINE = Util.memoize(
             (drawMode, cull) -> RenderPipelines.register(RenderPipeline.builder(RenderPipelines.ENTITY_SNIPPET)
                     .withLocation("pipeline/entity_translucent")
-//? if >=26.2-alpha.1 {
-                    /*.withBindGroupLayout(BindGroupLayouts.SAMPLER1)
+//? if >=26.2 {
+                    .withBindGroupLayout(BindGroupLayouts.SAMPLER1)
                     .withVertexBinding(0, DefaultVertexFormat.ENTITY)
                     .withPrimitiveTopology(drawMode)
                     .withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
-*///? } else if >=26.1 {
-                    .withSampler("Sampler1")
+//? } else if >=26.1 {
+                    /*.withSampler("Sampler1")
                     .withVertexFormat(DefaultVertexFormat.ENTITY, drawMode)
                     .withColorTargetState(new ColorTargetState(BlendFunction.TRANSLUCENT))
-//? } else {
+*///? } else {
                     /*.withSampler("Sampler1")
                     .withVertexFormat(DefaultVertexFormat.NEW_ENTITY, drawMode)
                     .withBlend(BlendFunction.TRANSLUCENT)
@@ -67,14 +67,14 @@ public class BufferBuildersManagerImpl implements BufferBuildersManager {
 
     private static final BiFunction</*? if >=1.21.11 {*/Identifier/*? } else {*//*ResourceLocation*//*? }*/, Boolean, RenderType> QUADS = Util.memoize(
             (texture, cull) -> {
-                RenderPipeline pipeline = PIPELINE.apply(/*? if >=26.2-alpha.1 {*//*PrimitiveTopology.QUADS*//*? } else {*/VertexFormat.Mode.QUADS/*? }*/, cull);
+                RenderPipeline pipeline = PIPELINE.apply(/*? if >=26.2 {*/PrimitiveTopology.QUADS/*? } else {*//*VertexFormat.Mode.QUADS*//*? }*/, cull);
                 return RenderType.create("bteterrarenderer-quads", generateSetup(pipeline, texture));
             }
     );
 
     private static final BiFunction</*? if >=1.21.11 {*/Identifier/*? } else {*//*ResourceLocation*//*? }*/, Boolean, RenderType> TRIS = Util.memoize(
             (texture, cull) -> {
-                RenderPipeline pipeline = PIPELINE.apply(/*? if >=26.2-alpha.1 {*//*PrimitiveTopology.TRIANGLES*//*? } else {*/VertexFormat.Mode.TRIANGLES/*? }*/, cull);
+                RenderPipeline pipeline = PIPELINE.apply(/*? if >=26.2 {*/PrimitiveTopology.TRIANGLES/*? } else {*//*VertexFormat.Mode.TRIANGLES*//*? }*/, cull);
                 return RenderType.create("bteterrarenderer-tris", generateSetup(pipeline, texture));
             }
     );
@@ -153,23 +153,23 @@ public class BufferBuildersManagerImpl implements BufferBuildersManager {
             }
             @Override
             public void nextShape(GraphicsQuad<PosTex> shape) {
-//? if >=26.2-alpha.1 {
-                /*context.submitNodeCollector().submitCustomGeometry(context.poseStack(), renderLayer, (pose, buffer) -> {
+//? if >=26.2 {
+                context.submitNodeCollector().submitCustomGeometry(context.poseStack(), renderLayer, (pose, buffer) -> {
                     McCoordTransformer transformer = this.getTransformer();
                     nextVertex(pose, buffer, transformer.transform(shape.v0.pos), shape.v0.tex, DEFAULT_NORMAL, alpha);
                     nextVertex(pose, buffer, transformer.transform(shape.v1.pos), shape.v1.tex, DEFAULT_NORMAL, alpha);
                     nextVertex(pose, buffer, transformer.transform(shape.v2.pos), shape.v2.tex, DEFAULT_NORMAL, alpha);
                     nextVertex(pose, buffer, transformer.transform(shape.v3.pos), shape.v3.tex, DEFAULT_NORMAL, alpha);
                 });
-*///? } else {
-                PoseStack.Pose pose = context.poseStack().last();
+//? } else {
+                /*PoseStack.Pose pose = context.poseStack().last();
                 VertexConsumer buffer = context.bufferSource().getBuffer(renderLayer);
                 McCoordTransformer transformer = this.getTransformer();
                 nextVertex(pose, buffer, transformer.transform(shape.v0.pos), shape.v0.tex, DEFAULT_NORMAL, alpha);
                 nextVertex(pose, buffer, transformer.transform(shape.v1.pos), shape.v1.tex, DEFAULT_NORMAL, alpha);
                 nextVertex(pose, buffer, transformer.transform(shape.v2.pos), shape.v2.tex, DEFAULT_NORMAL, alpha);
                 nextVertex(pose, buffer, transformer.transform(shape.v3.pos), shape.v3.tex, DEFAULT_NORMAL, alpha);
-//? }
+*///? }
             }
         };
     }
@@ -190,8 +190,8 @@ public class BufferBuildersManagerImpl implements BufferBuildersManager {
             }
             @Override
             public void nextShape(GraphicsTriangle<PosTexNorm> shape) {
-//? if >=26.2-alpha.1 {
-                /*context.submitNodeCollector().submitCustomGeometry(context.poseStack(), renderLayer, (pose, buffer) -> {
+//? if >=26.2 {
+                context.submitNodeCollector().submitCustomGeometry(context.poseStack(), renderLayer, (pose, buffer) -> {
                     McCoordTransformer transformer = this.getTransformer();
                     PosTexNorm tv0 = shape.v0.transform(transformer);
                     nextVertex(pose, buffer, tv0.pos, tv0.tex, enableNormal ? tv0.normal : DEFAULT_NORMAL, alpha);
@@ -200,8 +200,8 @@ public class BufferBuildersManagerImpl implements BufferBuildersManager {
                     PosTexNorm tv2 = shape.v2.transform(transformer);
                     nextVertex(pose, buffer, tv2.pos, tv2.tex, enableNormal ? tv2.normal : DEFAULT_NORMAL, alpha);
                 });
-*///? } else {
-                PoseStack.Pose pose = context.poseStack().last();
+//? } else {
+                /*PoseStack.Pose pose = context.poseStack().last();
                 VertexConsumer buffer = context.bufferSource().getBuffer(renderLayer);
                 McCoordTransformer transformer = this.getTransformer();
                 PosTexNorm tv0 = shape.v0.transform(transformer);
@@ -210,7 +210,7 @@ public class BufferBuildersManagerImpl implements BufferBuildersManager {
                 nextVertex(pose, buffer, tv1.pos, tv1.tex, enableNormal ? tv1.normal : DEFAULT_NORMAL, alpha);
                 PosTexNorm tv2 = shape.v2.transform(transformer);
                 nextVertex(pose, buffer, tv2.pos, tv2.tex, enableNormal ? tv2.normal : DEFAULT_NORMAL, alpha);
-//? }
+*///? }
             }
         };
     }

--- a/src/client/java/com/mndk/bteterrarenderer/mcconnector/client/graphics/WorldDrawContextWrapperImpl.java
+++ b/src/client/java/com/mndk/bteterrarenderer/mcconnector/client/graphics/WorldDrawContextWrapperImpl.java
@@ -7,9 +7,9 @@ import javax.annotation.Nonnull;
 
 public record WorldDrawContextWrapperImpl(
         @Nonnull PoseStack poseStack,
-//? if >=26.2-alpha.1 {
-        /*@Nonnull SubmitNodeCollector submitNodeCollector
-*///? } else {
-        @Nonnull MultiBufferSource bufferSource
-//? }
+//? if >=26.2 {
+        @Nonnull SubmitNodeCollector submitNodeCollector
+//? } else {
+        /*@Nonnull MultiBufferSource bufferSource
+*///? }
 ) implements WorldDrawContextWrapper {}

--- a/src/client/java/com/mndk/bteterrarenderer/mcconnector/client/text/TextManagerImpl.java
+++ b/src/client/java/com/mndk/bteterrarenderer/mcconnector/client/text/TextManagerImpl.java
@@ -52,11 +52,11 @@ public class TextManagerImpl implements TextManager {
     @Override
     public boolean handleClick(@Nonnull StyleWrapper styleWrapper) {
         Minecraft client = Minecraft.getInstance();
-//? if >=26.2-alpha.1 {
-        /*Screen currentScreen = client.gui.screen();
-*///? } else {
-        Screen currentScreen = client.screen;
-//? }
+//? if >=26.2 {
+        Screen currentScreen = client.gui.screen();
+//? } else {
+        /*Screen currentScreen = client.screen;
+*///? }
         if (currentScreen == null) return false;
 
         Style style = ((StyleWrapperImpl) styleWrapper).delegate();

--- a/src/client/java/com/mndk/bteterrarenderer/mixin/ChatComponentMixin.java
+++ b/src/client/java/com/mndk/bteterrarenderer/mixin/ChatComponentMixin.java
@@ -51,11 +51,11 @@ public class ChatComponentMixin {
 *///? }
         pose./*? if >=1.21.6 {*/pushMatrix()/*? } else {*//*pushPose()*//*? }*/;
 
-//? if >=26.2-alpha.1 {
-        /*Screen currentScreen = Minecraft.getInstance().gui.screen();
-*///? } else {
-        Screen currentScreen = Minecraft.getInstance().screen;
-//? }
+//? if >=26.2 {
+        Screen currentScreen = Minecraft.getInstance().gui.screen();
+//? } else {
+        /*Screen currentScreen = Minecraft.getInstance().screen;
+*///? }
         if (!(currentScreen instanceof AbstractGuiScreenImpl screenImpl)) return;
         if (!(screenImpl.delegate instanceof MapRenderingOptionsSidebar sidebar)) return;
         if (sidebar.side.get() != SidebarSide.LEFT) return;
@@ -97,11 +97,11 @@ public class ChatComponentMixin {
 
     @Inject(method = "isChatFocused", at = @At(value = "RETURN"), cancellable = true)
     public void isChatFocused(CallbackInfoReturnable<Boolean> cir) {
-//? if >=26.2-alpha.1 {
-        /*if (minecraft.gui.screen() instanceof AbstractGuiScreenImpl screenImpl) {
-*///? } else {
-        if (minecraft.screen instanceof AbstractGuiScreenImpl screenImpl) {
-//? }
+//? if >=26.2 {
+        if (minecraft.gui.screen() instanceof AbstractGuiScreenImpl screenImpl) {
+//? } else {
+        /*if (minecraft.screen instanceof AbstractGuiScreenImpl screenImpl) {
+*///? }
             cir.setReturnValue(screenImpl.delegate.isChatFocused());
         }
     }

--- a/src/client/java/com/mndk/bteterrarenderer/mixin/GuiMixin.java
+++ b/src/client/java/com/mndk/bteterrarenderer/mixin/GuiMixin.java
@@ -14,8 +14,8 @@ import javax.annotation.Nullable;
 @Mixin(Gui.class)
 public class GuiMixin {
 
-//? if >=26.2-alpha.1 {
-    /*@Shadow @Nullable private Screen screen;
+//? if >=26.2 {
+    @Shadow @Nullable private Screen screen;
 
     @Inject(method = "setScreen", at = @At(value = "HEAD"), cancellable = true)
     public void preSetScreen(Screen screen, CallbackInfo ci) {
@@ -24,6 +24,6 @@ public class GuiMixin {
             if (!escapable) ci.cancel();
         }
     }
-*///? }
+//? }
 
 }

--- a/src/client/java/com/mndk/bteterrarenderer/mixin/MinecraftMixin.java
+++ b/src/client/java/com/mndk/bteterrarenderer/mixin/MinecraftMixin.java
@@ -14,8 +14,8 @@ import javax.annotation.Nullable;
 @Mixin(Minecraft.class)
 public class MinecraftMixin {
 
-//? if <26.2-alpha.1 {
-    @Shadow @Nullable public Screen screen;
+//? if <26.2 {
+    /*@Shadow @Nullable public Screen screen;
 
     @Inject(method = "setScreen", at = @At(value = "HEAD"), cancellable = true)
     public void preSetScreen(Screen screen, CallbackInfo ci) {
@@ -24,6 +24,6 @@ public class MinecraftMixin {
             if (!escapable) ci.cancel();
         }
     }
-//? }
+*///? }
 
 }

--- a/src/client/java/com/mndk/bteterrarenderer/mixin/ScreenMixin.java
+++ b/src/client/java/com/mndk/bteterrarenderer/mixin/ScreenMixin.java
@@ -13,11 +13,11 @@ public abstract class ScreenMixin {
 
     @Inject(method = "onClose", at = @At("HEAD"), cancellable = true)
     public void onClose(CallbackInfo ci) {
-//? if >=26.2-alpha.1 {
-        /*Screen currentScreen = Minecraft.getInstance().gui.screen();
-*///? } else {
-        Screen currentScreen = Minecraft.getInstance().screen;
-//? }
+//? if >=26.2 {
+        Screen currentScreen = Minecraft.getInstance().gui.screen();
+//? } else {
+        /*Screen currentScreen = Minecraft.getInstance().screen;
+*///? }
         if (currentScreen instanceof AbstractGuiScreenImpl screenImpl) {
             boolean escapable = screenImpl.delegate.handleScreenEscape();
             if (!escapable) ci.cancel();

--- a/src/client/java/com/mndk/bteterrarenderer/mod/client/event/RenderEvents.java
+++ b/src/client/java/com/mndk/bteterrarenderer/mod/client/event/RenderEvents.java
@@ -59,24 +59,24 @@ public class RenderEvents {
         Minecraft client = Minecraft.getInstance();
         if (client.level == null || client.player == null) return;
 
-//? if >=26.2-alpha.1 {
-        /*PoseStack stack = renderContext.poseStack();
-        var submitNodeCollectorOrBufferSource = renderContext.submitNodeCollector();
-*///? } else if >=26.1 {
+//? if >=26.2 {
         PoseStack stack = renderContext.poseStack();
+        var submitNodeCollectorOrBufferSource = renderContext.submitNodeCollector();
+//? } else if >=26.1 {
+        /*PoseStack stack = renderContext.poseStack();
         var submitNodeCollectorOrBufferSource = renderContext.bufferSource();
-//? } else {
+*///? } else {
         /*PoseStack stack = renderContext.matrices();
         var submitNodeCollectorOrBufferSource = renderContext.consumers();
 *///? }
         if (stack == null || submitNodeCollectorOrBufferSource == null) return;
 
         WorldDrawContextWrapper context = new WorldDrawContextWrapperImpl(stack, submitNodeCollectorOrBufferSource);
-//? if >=26.2-alpha.1 {
-        /*Camera camera = renderContext.gameRenderer().mainCamera();
-*///? } else {
-        Camera camera = renderContext.gameRenderer().getMainCamera();
-//? }
+//? if >=26.2 {
+        Camera camera = renderContext.gameRenderer().mainCamera();
+//? } else {
+        /*Camera camera = renderContext.gameRenderer().getMainCamera();
+*///? }
         Vec3 cameraPos = camera.position();
 //? } else {
         /*var world = renderContext.world();

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -6,7 +6,7 @@ val ciSingleBuild: String? = System.getenv("CI_SINGLE_BUILD")
 if (ciSingleBuild != null) {
     stonecutter active ciSingleBuild.split(":")[0]
 } else {
-    stonecutter active "fabric26.1"
+    stonecutter active "fabric26.2"
 }
 
 subprojects {

--- a/stonecutter.properties.toml
+++ b/stonecutter.properties.toml
@@ -1,13 +1,13 @@
-["fabric26.2-snapshot-6"]
-minecraftVersion = "~26.2-alpha.6"
+["fabric26.2"]
+minecraftVersion = "~26.2"
 modLoaderName = "fabric"
-fabricVersion = "0.148.2+26.2"
+fabricVersion = "0.152.1+26.2"
 aw = "26.1.accesswidener"
 
 ["fabric26.1"]
 minecraftVersion = "~26.1"
 modLoaderName = "fabric"
-fabricVersion = "0.148.2+26.1.2"
+fabricVersion = "0.152.1+26.1.2"
 aw = "26.1.accesswidener"
 
 ["fabric1.21.11"]

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://stonecutter.kikugie.dev/settings-schema/latest.json",
   "versions": [
-    "fabric26.2-snapshot-6:26.2-snapshot-6:build.fabric.gradle.kts",
+    "fabric26.2:26.2:build.fabric.gradle.kts",
     "fabric26.1:26.1:build.fabric.gradle.kts",
 
     "fabric1.21.11:1.21.11:build.fabric.gradle.kts",


### PR DESCRIPTION
Usual chores after new Minecraft releases. No changes since the port to 26.2-snapshot-6 in 74acec6 other than making 26.2 the main version and updating fabric-api for 26.1 and 26.2.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2aeaa6a7-5191-48a4-96f4-f11fabf53772" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/5a76af38-dc81-4b9f-9f64-48db5048f768" />
