### PR TITLE
feat: support nested map source categories

### DIFF
--- a/common/src/main/java/com/mndk/bteterrarenderer/util/category/Category.java
+++ b/common/src/main/java/com/mndk/bteterrarenderer/util/category/Category.java
@@ -16,11 +16,22 @@ import java.util.Set;
 public class Category<T> {
     // internal map of id to wrapper
     private final Map<String, T> entries = new LinkedHashMap<>();
+    private final Map<String, Category<T>> subcategories = new LinkedHashMap<>();
 
     public <E extends Throwable> void forEach(ThrowableBiConsumer<String, T, E> consumer) throws E {
         for (Entry<String, T> entry : entries.entrySet()) {
             consumer.accept(entry.getKey(), entry.getValue());
         }
+    }
+
+    public void forEach(String[] path, CategoryMap.PathConsumer<T> consumer) {
+        entries.forEach((id, item) -> consumer.accept(path, id, item));
+        subcategories.forEach((subName, subcategory) -> {
+            String[] subPath = new String[path.length + 1];
+            System.arraycopy(path, 0, subPath, 0, path.length);
+            subPath[path.length] = subName;
+            subcategory.forEach(subPath, consumer);
+        });
     }
 
     // accessors for entries

--- a/common/src/main/java/com/mndk/bteterrarenderer/util/category/CategoryMap.java
+++ b/common/src/main/java/com/mndk/bteterrarenderer/util/category/CategoryMap.java
@@ -17,7 +17,7 @@ import java.util.function.BiConsumer;
 @JsonDeserialize(using = CategoryMapDeserializer.class)
 public class CategoryMap<T> {
 
-	@Getter(AccessLevel.PACKAGE)
+	@Getter
 	private final Map<String, Category<T>> map = new LinkedHashMap<>();
 
 	public void forEach(BiConsumer<String, Category<T>> consumer) {
@@ -30,15 +30,42 @@ public class CategoryMap<T> {
 		}
 	}
 
+	public interface PathConsumer<T> {
+		void accept(String[] categoryPath, String id, T item);
+	}
+
+	public void forEach(PathConsumer<T> consumer) {
+		map.forEach((name, category) -> category.forEach(new String[]{name}, consumer));
+	}
+
 	@Nullable
 	public T getItem(String categoryName, String elementId) {
-		Category<T> category = map.get(categoryName);
-		if (category == null) return null;
-		return category.get(elementId);
+		return getItem(new String[]{categoryName}, elementId);
+	}
+
+	@Nullable
+	public T getItem(String[] categoryPath, String elementId) {
+		if (categoryPath == null || categoryPath.length == 0) return null;
+		Category<T> current = map.get(categoryPath[0]);
+		for (int i = 1; i < categoryPath.length; i++) {
+			if (current == null) return null;
+			current = current.getSubcategories().get(categoryPath[i]);
+		}
+		if (current == null) return null;
+		return current.get(elementId);
 	}
 
 	public void setItem(String categoryName, String elementId, @Nonnull T item) {
-		map.computeIfAbsent(categoryName, n -> new Category<>()).put(elementId, item);
+		setItem(new String[]{categoryName}, elementId, item);
+	}
+
+	public void setItem(String[] categoryPath, String elementId, @Nonnull T item) {
+		if (categoryPath == null || categoryPath.length == 0) return;
+		Category<T> current = map.computeIfAbsent(categoryPath[0], n -> new Category<>());
+		for (int i = 1; i < categoryPath.length; i++) {
+			current = current.getSubcategories().computeIfAbsent(categoryPath[i], n -> new Category<>());
+		}
+		current.put(elementId, item);
 	}
 
 	@Getter

--- a/common/src/main/java/com/mndk/bteterrarenderer/util/category/CategoryMapDeserializer.java
+++ b/common/src/main/java/com/mndk/bteterrarenderer/util/category/CategoryMapDeserializer.java
@@ -37,16 +37,44 @@ class CategoryMapDeserializer extends JsonDeserializer<CategoryMap<?>> implement
             if (!categoryNode.isObject())
                 throw JsonMappingException.from(p, "category should be an object");
 
-            Category<Object> category = new Category<>();
-            for (Iterator<Map.Entry<String, JsonNode>> it = categoryNode.fields(); it.hasNext(); ) {
-                Map.Entry<String, JsonNode> valueEntry = it.next();
-                String valueId = valueEntry.getKey();
-                category.put(valueId, ctxt.readTreeAsValue(valueEntry.getValue(), this.valueType));
-            }
-
-            result.getMap().put(categoryName, category);
+            result.getMap().put(categoryName, deserializeCategory(categoryNode, ctxt));
         }
 
         return result;
+    }
+
+    private Category<Object> deserializeCategory(JsonNode node, DeserializationContext ctxt) throws IOException {
+        Category<Object> category = new Category<>();
+        for (Iterator<Map.Entry<String, JsonNode>> it = node.fields(); it.hasNext(); ) {
+            Map.Entry<String, JsonNode> entry = it.next();
+            String key = entry.getKey();
+            JsonNode childNode = entry.getValue();
+
+            if (isLeafNode(childNode)) {
+                category.put(key, ctxt.readTreeAsValue(childNode, this.valueType));
+            } else {
+                category.getSubcategories().put(key, deserializeCategory(childNode, ctxt));
+            }
+        }
+        return category;
+    }
+
+    private boolean isLeafNode(JsonNode node) {
+        if (!node.isObject()) return true;
+
+        if (this.valueType != null) {
+            Class<?> rawClass = this.valueType.getRawClass();
+            if (Map.class.isAssignableFrom(rawClass)) {
+                for (Iterator<JsonNode> it = node.elements(); it.hasNext(); ) {
+                    JsonNode child = it.next();
+                    if (child.isObject()) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        }
+
+        return node.has("type");
     }
 }

--- a/common/src/main/java/com/mndk/bteterrarenderer/util/category/CategoryMapSerializer.java
+++ b/common/src/main/java/com/mndk/bteterrarenderer/util/category/CategoryMapSerializer.java
@@ -11,17 +11,24 @@ class CategoryMapSerializer extends JsonSerializer<CategoryMap<Object>> {
     public void serialize(CategoryMap<Object> map, JsonGenerator gen, SerializerProvider serializers) throws IOException {
         gen.writeStartObject(); // main
 
-        map.forEachThrowable((categoryName, category) -> {
-            gen.writeFieldName(categoryName);
-            gen.writeStartObject();
-
-            category.forEach((id, value) -> {
-                gen.writeFieldName(id);
-                gen.writeObject(value);
-            });
-            gen.writeEndObject();
-        });
+        for (java.util.Map.Entry<String, Category<Object>> entry : map.getMap().entrySet()) {
+            gen.writeFieldName(entry.getKey());
+            serializeCategory(entry.getValue(), gen);
+        }
 
         gen.writeEndObject(); // main
+    }
+
+    private void serializeCategory(Category<Object> category, JsonGenerator gen) throws IOException {
+        gen.writeStartObject();
+        for (java.util.Map.Entry<String, Object> entry : category.getEntries().entrySet()) {
+            gen.writeFieldName(entry.getKey());
+            gen.writeObject(entry.getValue());
+        }
+        for (java.util.Map.Entry<String, Category<Object>> sub : category.getSubcategories().entrySet()) {
+            gen.writeFieldName(sub.getKey());
+            serializeCategory(sub.getValue(), gen);
+        }
+        gen.writeEndObject();
     }
 }

--- a/common/src/main/java/com/mndk/bteterrarenderer/util/merge/CategoryMapMergeStrategy.java
+++ b/common/src/main/java/com/mndk/bteterrarenderer/util/merge/CategoryMapMergeStrategy.java
@@ -8,9 +8,6 @@ import com.mndk.bteterrarenderer.util.category.CategoryMap;
 public class CategoryMapMergeStrategy<V> implements MergeStrategy<CategoryMap<V>> {
     @Override
     public void merge(CategoryMap<V> original, CategoryMap<V> addition) {
-        // merge each item from addition into original without using deprecated append()
-        addition.forEach((categoryName, category) ->
-                category.forEach((id, value) -> original.setItem(categoryName, id, value))
-        );
+        addition.forEach((categoryPath, id, value) -> original.setItem(categoryPath, id, value));
     }
 }

--- a/core/src/main/java/com/mndk/bteterrarenderer/core/config/BTETerraRendererConfig.java
+++ b/core/src/main/java/com/mndk/bteterrarenderer/core/config/BTETerraRendererConfig.java
@@ -26,6 +26,14 @@ public class BTETerraRendererConfig {
 
         @ConfigName("Map Service ID")
         public String mapServiceId = "osm";
+
+        public String[] getMapServiceCategoryPath() {
+            return this.mapServiceCategory.split("/");
+        }
+
+        public void setMapServiceCategoryPath(String[] path) {
+            this.mapServiceCategory = String.join("/", path);
+        }
     }
 
     @ConfigName("Hologram Settings")

--- a/core/src/main/java/com/mndk/bteterrarenderer/core/gui/MapRenderingOptionsSidebar.java
+++ b/core/src/main/java/com/mndk/bteterrarenderer/core/gui/MapRenderingOptionsSidebar.java
@@ -27,12 +27,15 @@ import com.mndk.bteterrarenderer.util.accessor.PropertyAccessor;
 import com.mndk.bteterrarenderer.util.category.CategoryMap;
 import com.mndk.bteterrarenderer.util.concurrent.CacheStorage;
 import com.mndk.bteterrarenderer.util.concurrent.ManualThreadExecutor;
+import com.mndk.bteterrarenderer.util.image.ImageUtil;
 
 import javax.annotation.Nonnull;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class MapRenderingOptionsSidebar extends GuiSidebar {
 
@@ -40,6 +43,7 @@ public class MapRenderingOptionsSidebar extends GuiSidebar {
     private static final int SIDE_PADDING = 7;
     private static final int ELEMENT_DISTANCE_BIG = 35;
 
+    private static final ExecutorService MULTI_THREADED = Executors.newCachedThreadPool();
     private static final ManualThreadExecutor ICON_MAKER = new ManualThreadExecutor();
     private static final IconStorage ICON_STORAGE = new IconStorage();
 
@@ -172,10 +176,11 @@ public class MapRenderingOptionsSidebar extends GuiSidebar {
     }
 
     private String[] getWrappedTMS() {
-        return new String[] {
-                BTETerraRendererConfig.GENERAL.getMapServiceCategory(),
-                BTETerraRendererConfig.GENERAL.getMapServiceId()
-        };
+        String[] categoryPath = BTETerraRendererConfig.GENERAL.getMapServiceCategoryPath();
+        String[] wrapped = new String[categoryPath.length + 1];
+        System.arraycopy(categoryPath, 0, wrapped, 0, categoryPath.length);
+        wrapped[categoryPath.length] = BTETerraRendererConfig.GENERAL.getMapServiceId();
+        return wrapped;
     }
 
     private void updateTmsSettings() {
@@ -220,27 +225,27 @@ public class MapRenderingOptionsSidebar extends GuiSidebar {
     }
 
     private void setTileMapServiceCategoryPath(String[] categoryPath) {
-        if (categoryPath == null || categoryPath.length != 2) {
-            throw new IllegalArgumentException("Category stack must have exactly 3 elements: "
-                    + "[categoryName, id]. Current: "
+        if (categoryPath == null || categoryPath.length < 2) {
+            throw new IllegalArgumentException("Category stack must have at least 2 elements: "
+                    + "[...categoryPath, id]. Current: "
                     + Arrays.toString(categoryPath));
         }
-        String categoryName = categoryPath[0];
-        String id = categoryPath[1];
-        BTETerraRendererConfig.GENERAL.setMapServiceCategory(categoryName);
+        String[] categories = Arrays.copyOf(categoryPath, categoryPath.length - 1);
+        String id = categoryPath[categoryPath.length - 1];
+        BTETerraRendererConfig.GENERAL.setMapServiceCategoryPath(categories);
         BTETerraRendererConfig.GENERAL.setMapServiceId(id);
         this.updateTmsSettings();
     }
 
     private static String tmsWrappedToString(String[] categoryPath) {
-        if (categoryPath == null || categoryPath.length != 2) {
-            throw new IllegalArgumentException("Category stack must have exactly 3 elements: "
-                    + "[categoryName, id]. Current: "
+        if (categoryPath == null || categoryPath.length < 2) {
+            throw new IllegalArgumentException("Category stack must have at least 2 elements: "
+                    + "[...categoryPath, id]. Current: "
                     + Arrays.toString(categoryPath));
         }
-        String categoryName = categoryPath[0];
-        String id = categoryPath[1];
-        TileMapService tms = LoaderRegistry.tms().getResult().getItem(categoryName, id);
+        String[] categories = Arrays.copyOf(categoryPath, categoryPath.length - 1);
+        String id = categoryPath[categoryPath.length - 1];
+        TileMapService tms = LoaderRegistry.tms().getResult().getItem(categories, id);
         if (tms == null) {
             return "[§7null§r]\n§4§o(error)";
         }
@@ -263,12 +268,21 @@ public class MapRenderingOptionsSidebar extends GuiSidebar {
         McFXDropdown.ItemListUpdater updater = mapSourceDropdown.itemListBuilder();
 
         CategoryMap<TileMapService> tmsCategoryMap = LoaderRegistry.tms().getResult();
-        tmsCategoryMap.forEach((name, category) -> {
+        tmsCategoryMap.getMap().forEach((name, category) -> {
             updater.push(name);
-            category.forEach((id, tms) -> updater.add(id));
+            this.addCategoryToDropdown(updater, category);
             updater.pop();
         });
         updater.update();
+    }
+
+    private void addCategoryToDropdown(McFXDropdown.ItemListUpdater updater, com.mndk.bteterrarenderer.util.category.Category<TileMapService> category) {
+        category.getEntries().forEach((id, tms) -> updater.add(id));
+        category.getSubcategories().forEach((name, subcategory) -> {
+            updater.push(name);
+            this.addCategoryToDropdown(updater, subcategory);
+            updater.pop();
+        });
     }
 
     private void openMapsFolder() {
@@ -276,20 +290,24 @@ public class MapRenderingOptionsSidebar extends GuiSidebar {
     }
 
     private static NativeTextureWrapper getIconTextureObject(String[] categoryPath) {
-        if (categoryPath == null || categoryPath.length != 2) {
-            throw new IllegalArgumentException("Category stack must have exactly 3 elements: "
-                    + "[categoryName, id]. Current: "
+        if (categoryPath == null || categoryPath.length < 2) {
+            throw new IllegalArgumentException("Category stack must have at least 2 elements: "
+                    + "[...categoryPath, id]. Current: "
                     + Arrays.toString(categoryPath));
         }
-        String categoryName = categoryPath[0];
-        String id = categoryPath[1];
-        TileMapService tms = LoaderRegistry.tms().getResult().getItem(categoryName, id);
+        String[] categories = Arrays.copyOf(categoryPath, categoryPath.length - 1);
+        String id = categoryPath[categoryPath.length - 1];
+        TileMapService tms = LoaderRegistry.tms().getResult().getItem(categories, id);
         if (tms == null) return null;
 
         URL iconUrl = tms.getIconUrl();
         if (iconUrl == null) return null;
 
-        return ICON_STORAGE.getOrCompute(iconUrl, () -> HttpResourceManager.downloadAsImage(iconUrl.toString(), -1, 256, 256)
+        return ICON_STORAGE.getOrCompute(iconUrl, () -> HttpResourceManager.downloadAsImage(iconUrl.toString(), null)
+                .thenApplyAsync(
+                        image -> ImageUtil.resizeImage(image, 256, 256),
+                        MULTI_THREADED
+                )
                 .thenApplyAsync(
                         image -> McConnector.client().textureManager.allocateAndGetTextureObject(BTETerraRenderer.MODID, image),
                         ICON_MAKER

--- a/core/src/main/java/com/mndk/bteterrarenderer/core/loader/LoaderRegistry.java
+++ b/core/src/main/java/com/mndk/bteterrarenderer/core/loader/LoaderRegistry.java
@@ -27,7 +27,7 @@ public class LoaderRegistry {
 
     public TileMapService getCurrentTMS() {
         BTETerraRendererConfig.GeneralConfig config = BTETerraRendererConfig.GENERAL;
-        return TMS_YML.getResult().getItem(config.mapServiceCategory, config.mapServiceId);
+        return TMS_YML.getResult().getItem(config.getMapServiceCategoryPath(), config.mapServiceId);
     }
 
     public TileMapServiceLoader tms() {

--- a/core/src/main/java/com/mndk/bteterrarenderer/core/loader/json/TileMapServiceStateLoader.java
+++ b/core/src/main/java/com/mndk/bteterrarenderer/core/loader/json/TileMapServiceStateLoader.java
@@ -36,11 +36,11 @@ public class TileMapServiceStateLoader implements ConfigLoader<CategoryMap<TileM
     }
 
     private void applyRawFileData(@Nonnull CategoryMap<TileMapService> tmsCategoryMap, TileMapServicePropertyDTO raw) {
-        raw.getCategories().forEach((categoryName, category) -> category.forEach((id, map) -> {
-            TileMapService tms = tmsCategoryMap.getItem(categoryName, id);
+        raw.getCategories().forEach((categoryPath, id, map) -> {
+            TileMapService tms = tmsCategoryMap.getItem(categoryPath, id);
             if (tms == null || map == null) return; // skip if TMS not found
             this.applyRawStates(tms, map);
-        }));
+        });
     }
 
     private void applyRawStates(@Nonnull TileMapService tms, Map<String, Object> rawValues) {
@@ -68,11 +68,11 @@ public class TileMapServiceStateLoader implements ConfigLoader<CategoryMap<TileM
 
     private CategoryMap<Map<String, Object>> prepareRawFileData(@Nonnull CategoryMap<TileMapService> tmsCategoryMap) {
         CategoryMap<Map<String, Object>> map = new CategoryMap<>();
-        tmsCategoryMap.forEach((categoryName, category) -> category.forEach((id, tms) -> {
+        tmsCategoryMap.forEach((categoryPath, id, tms) -> {
             Map<String, Object> propertyValues = new HashMap<>();
             this.saveRawStates(tms, propertyValues);
-            map.setItem(categoryName, id, propertyValues);
-        }));
+            map.setItem(categoryPath, id, propertyValues);
+        });
         return map;
     }
 

--- a/core/src/main/java/com/mndk/bteterrarenderer/core/loader/yml/TileMapServiceLoader.java
+++ b/core/src/main/java/com/mndk/bteterrarenderer/core/loader/yml/TileMapServiceLoader.java
@@ -23,9 +23,7 @@ public class TileMapServiceLoader extends YamlLoader<TileMapServiceDTO, Category
 
     protected CategoryMap<TileMapService> load(String fileName, TileMapServiceDTO content) {
         CategoryMap<TileMapService> categoryMap = content.getCategories();
-        categoryMap.forEach((categoryName, category) ->
-                category.forEach((key, tms) -> tms.setSource(fileName))
-        );
+        categoryMap.forEach((categoryPath, key, tms) -> tms.setSource(fileName));
         return categoryMap;
     }
 }

--- a/core/src/main/resources/assets/bteterrarenderer/default_maps.yml
+++ b/core/src/main/resources/assets/bteterrarenderer/default_maps.yml
@@ -161,33 +161,34 @@ categories:
          max_thread: 2
          default_zoom: 20
 
-      tp_ortho_tw:
-         type: "flat"
-         name:
-            en_us: "Taipei Aerial Orthophoto"
-            zh_tw: "臺北市航測影像"
-         copyright:
-            en_us: ["",{"text":"© ","color":"white"},{"text":"Department of Urban Development, Taipei City Government, ROC","underlined":true,"color":"aqua","clickEvent":{"action":"open_url","value":"https://www.historygis.udd.gov.taipei/urban/"}}]
-            zh_tw: ["",{"text":"© ","color":"white"},{"text":"臺北市政府都市發展局","underlined":true,"color":"aqua","clickEvent":{"action":"open_url","value":"https://www.historygis.udd.gov.taipei/urban/"}},{"text":"版權所有","color":"white"}]
-         tile_url: https://www.historygis.udd.gov.taipei/arcgis/rest/services/Aerial/Ortho_2023/MapServer/WMTS/tile/1.0.0/Aerial_Ortho_2023/default/default028mm/{z}/{y}/{x}.png
-         icon_url: https://www.historygis.udd.gov.taipei/urban/assets/images/logo.svg
-         projection: webmercator
-         max_thread: 2
-         default_zoom: 21
-      
-      tp_topo1k_tw:
-         type: "flat"
-         name:
-            en_us: "Taipei 1/1000 Topographic Map"
-            zh_tw: "臺北市1/1000地形圖"
-         copyright:
-            en_us: ["",{"text":"© ","color":"white"},{"text":"Department of Urban Development, Taipei City Government, ROC","underlined":true,"color":"aqua","clickEvent":{"action":"open_url","value":"https://www.historygis.udd.gov.taipei/urban/"}}]
-            zh_tw: ["",{"text":"© ","color":"white"},{"text":"臺北市政府都市發展局","underlined":true,"color":"aqua","clickEvent":{"action":"open_url","value":"https://www.historygis.udd.gov.taipei/urban/"}},{"text":"版權所有","color":"white"}]
-         tile_url: https://www.historygis.udd.gov.taipei/arcgis/rest/services/TOPO/DGN_2023/MapServer/WMTS/tile/1.0.0/TOPO_DGN_2023/default/GoogleMapsCompatible/{z}/{y}/{x}.png
-         icon_url: https://www.historygis.udd.gov.taipei/urban/assets/images/logo.svg
-         projection: webmercator
-         max_thread: 2
-         default_zoom: 21
+      臺北:
+         tp_ortho_tw:
+            type: "flat"
+            name:
+               en_us: "Taipei Aerial Orthophoto"
+               zh_tw: "臺北市航測影像"
+            copyright:
+               en_us: ["",{"text":"© ","color":"white"},{"text":"Department of Urban Development, Taipei City Government, ROC","underlined":true,"color":"aqua","clickEvent":{"action":"open_url","value":"https://www.historygis.udd.gov.taipei/urban/"}}]
+               zh_tw: ["",{"text":"© ","color":"white"},{"text":"臺北市政府都市發展局","underlined":true,"color":"aqua","clickEvent":{"action":"open_url","value":"https://www.historygis.udd.gov.taipei/urban/"}},{"text":"版權所有","color":"white"}]
+            tile_url: https://www.historygis.udd.gov.taipei/arcgis/rest/services/Aerial/Ortho_2023/MapServer/WMTS/tile/1.0.0/Aerial_Ortho_2023/default/default028mm/{z}/{y}/{x}.png
+            icon_url: https://www.historygis.udd.gov.taipei/urban/assets/images/logo.svg
+            projection: webmercator
+            max_thread: 2
+            default_zoom: 21
+
+         tp_topo1k_tw:
+            type: "flat"
+            name:
+               en_us: "Taipei 1/1000 Topographic Map"
+               zh_tw: "臺北市1/1000地形圖"
+            copyright:
+               en_us: ["",{"text":"© ","color":"white"},{"text":"Department of Urban Development, Taipei City Government, ROC","underlined":true,"color":"aqua","clickEvent":{"action":"open_url","value":"https://www.historygis.udd.gov.taipei/urban/"}}]
+               zh_tw: ["",{"text":"© ","color":"white"},{"text":"臺北市政府都市發展局","underlined":true,"color":"aqua","clickEvent":{"action":"open_url","value":"https://www.historygis.udd.gov.taipei/urban/"}},{"text":"版權所有","color":"white"}]
+            tile_url: https://www.historygis.udd.gov.taipei/arcgis/rest/services/TOPO/DGN_2023/MapServer/WMTS/tile/1.0.0/TOPO_DGN_2023/default/GoogleMapsCompatible/{z}/{y}/{x}.png
+            icon_url: https://www.historygis.udd.gov.taipei/urban/assets/images/logo.svg
+            projection: webmercator
+            max_thread: 2
+            default_zoom: 21
 
 
    Singapore:

--- a/mcconnector/src/main/java/com/mndk/bteterrarenderer/mcconnector/client/mcfx/dropdown/McFXDropdown.java
+++ b/mcconnector/src/main/java/com/mndk/bteterrarenderer/mcconnector/client/mcfx/dropdown/McFXDropdown.java
@@ -236,7 +236,7 @@ public class McFXDropdown extends McFXElement {
             McFXDropdownItemList list = stack.peek();
             McFXDropdownItemList victim = dropdownItems;
             for (int i = 0; i < stack.size(); i++) {
-                if (victim != null) victim = victim.findCategory(stack.get(0).name);
+                if (victim != null) victim = victim.findCategory(stack.get(i).name);
             }
             if (victim != null) list.opened = victim.opened;
 


### PR DESCRIPTION
Add support for multi-level category hierarchy in map source selection, enabling city-level subcategories under countries (e.g. Taiwan > Taipei).

- Add subcategories field to Category class with recursive forEach
- Update CategoryMap to use String[] path for get/set/forEach operations
- Update CategoryMap deserializer/serializer for recursive JSON/YAML
- Update CategoryMapMergeStrategy to work with category paths
- Add getMapServiceCategoryPath/setMapServiceCategoryPath to config
- Update MapRenderingOptionsSidebar to use category path selection
- Update loaders (LoaderRegistry, TileMapServiceStateLoader, TileMapServiceLoader) for path-based access
- Move Taipei map entries under Taiwan -> Taipei subcategory in default_maps.yml