### PR TITLE
👷 Add proper release workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,8 +5,16 @@ name: build
 
 on:
   push:
+    branches:
+      - "**"
+    tags:
+      - "!**"
   pull_request:
   workflow_dispatch:
+
+concurrency:
+  group: bteterrarenderer-${{ github.sha }}
+  cancel-in-progress: false
 
 jobs:
   generate-build-matrix:
@@ -18,7 +26,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -29,6 +37,7 @@ jobs:
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
   build:
+    if: github.event_name != 'push' || github.ref_type != 'tag'
     name: Build ${{ matrix.name }}
     needs: generate-build-matrix
     runs-on: ubuntu-latest
@@ -39,7 +48,7 @@ jobs:
 
     steps:
       - name: Check out repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -37,7 +37,6 @@ jobs:
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
   build:
-    if: github.event_name != 'push' || github.ref_type != 'tag'
     name: Build ${{ matrix.name }}
     needs: generate-build-matrix
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,311 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: bteterrarenderer-${{ github.sha }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: write
+
+jobs:
+  validate-release-tag:
+    runs-on: ubuntu-latest
+
+    outputs:
+      prerelease: ${{ steps.validate.outputs.prerelease }}
+
+    steps:
+      - name: Validate release tag
+        id: validate
+        shell: bash
+        run: |
+          set -euo pipefail
+          
+          tag="${GITHUB_REF_NAME}"
+          
+          # Supported:
+          # v1.2.3
+          # v1.2.3-alpha
+          # v1.2.3-alpha.4
+          # v1.2.3-beta
+          # v1.2.3-beta.2
+          #
+          # Only alpha and beta prerelease identifiers are supported because
+          # mc-publish infers its version type from those words.
+          pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(alpha|beta)(\.(0|[1-9][0-9]*))?)?$'
+          
+          if [[ ! "${tag}" =~ ${pattern} ]]; then
+            {
+              echo "Invalid release tag: ${tag}"
+              echo
+              echo "Allowed examples:"
+              echo "  v1.5.0"
+              echo "  v1.5.0-alpha"
+              echo "  v1.5.0-alpha.4"
+              echo "  v1.5.0-beta"
+              echo "  v1.5.0-beta.2"
+              echo
+              echo "Unsupported examples:"
+              echo "  v1.05.0"
+              echo "  v1.5.0-test4"
+              echo "  v1.5.0-rc1"
+            } >&2
+          
+            exit 1
+          fi
+          
+          if [[ "${tag}" == *-* ]]; then
+            prerelease="true"
+          else
+            prerelease="false"
+          fi
+          
+          echo "prerelease=${prerelease}" >> "$GITHUB_OUTPUT"
+          
+          {
+            echo "### Validated release tag"
+            echo
+            echo "- Tag: \`${tag}\`"
+            echo "- GitHub prerelease: \`${prerelease}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  generate-release-matrix:
+    needs:
+      - validate-release-tag
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      matrix: ${{ steps.generate-matrix.outputs.matrix }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Generate release matrix
+        id: generate-matrix
+        shell: bash
+        run: |
+          set -euo pipefail
+          
+          matrix=$(
+            jq -c '
+              {
+                include: (
+                  .versions
+                  | map({
+                      target: .,
+                      name: (split(":")[0]),
+                      mcversion: (split(":")[1])
+                    })
+                )
+              }
+            ' versions.json
+          )
+          
+          echo "matrix=${matrix}" >> "$GITHUB_OUTPUT"
+
+  locate-build-run:
+    needs:
+      - validate-release-tag
+
+    runs-on: ubuntu-latest
+
+    outputs:
+      run-id: ${{ steps.locate.outputs.run-id }}
+
+    steps:
+      - name: Find matching successful build
+        id: locate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          
+          run_id=$(
+            gh run list \
+              --workflow build \
+              --repo "$GITHUB_REPOSITORY" \
+              --commit "$GITHUB_SHA" \
+              --json databaseId,status,conclusion,event \
+              --limit 20 \
+              --jq '
+                .[]
+                | select(
+                    .event == "push"
+                    and .status == "completed"
+                    and .conclusion == "success"
+                  )
+                | .databaseId
+              ' \
+              | head -n 1
+          )
+          
+          if [[ -z "${run_id}" ]]; then
+            echo "No successful build workflow run found for ${GITHUB_SHA}" >&2
+            exit 1
+          fi
+          
+          echo "run-id=${run_id}" >> "$GITHUB_OUTPUT"
+
+  prepare-release-notes:
+    needs:
+      - validate-release-tag
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Prepare release notes
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          changelog_version="${tag%%-*}"
+          header="## ${changelog_version}"
+          notes_file="release-notes.md"
+
+          awk -v header="${header}" '
+            $0 == header {
+              printing = 1
+              found = 1
+              next
+            }
+
+            printing && /^##[[:space:]]/ {
+              exit
+            }
+
+            printing {
+              print
+            }
+
+            END {
+              if (!found) {
+                exit 1
+              }
+            }
+          ' CHANGELOG.md > "${notes_file}" || {
+            echo "No changelog section found for ${tag}" >&2
+            echo "Expected heading: ${header}" >&2
+            exit 1
+          }
+
+          if [[ ! -s "${notes_file}" ]]; then
+            echo "Changelog section ${header} is empty" >&2
+            exit 1
+          fi
+
+      - name: Upload release notes
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-notes
+          path: release-notes.md
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-platforms:
+    needs:
+      - validate-release-tag
+      - generate-release-matrix
+      - locate-build-run
+      - prepare-release-notes
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.generate-release-matrix.outputs.matrix) }}
+
+    steps:
+      - name: Download built artifact
+        uses: actions/download-artifact@v8
+        with:
+          pattern: '*-${{ matrix.name }}.jar'
+          path: artifact
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.locate-build-run.outputs.run-id }}
+          github-token: ${{ github.token }}
+
+      - name: Download release notes
+        uses: actions/download-artifact@v8
+        with:
+          name: release-notes
+          path: .
+
+      - name: Publish to Modrinth and CurseForge
+        uses: Kira-NT/mc-publish@v3
+        with:
+          modrinth-id: 1A8XMFfM
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+
+          curseforge-id: 1550742
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+
+          changelog-file: release-notes.md
+
+          # mc-publish infers the version type from this value:
+          # *-alpha* -> alpha
+          # *-beta*  -> beta
+          # otherwise -> release
+          version: ${{ github.ref_name }}-${{ matrix.mcversion }}
+
+          name: BTETerraRenderer ${{ github.ref_name }} for Minecraft ${{ matrix.mcversion }}
+
+          files: |
+            artifact/*.jar
+
+  publish-github-release:
+    needs:
+      - validate-release-tag
+      - locate-build-run
+      - prepare-release-notes
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all built artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: release-artifacts
+          pattern: '*'
+          merge-multiple: true
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.locate-build-run.outputs.run-id }}
+          github-token: ${{ github.token }}
+
+      - name: Download release notes
+        uses: actions/download-artifact@v8
+        with:
+          name: release-notes
+          path: .
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+
+          body_path: release-notes.md
+          generate_release_notes: true
+
+          prerelease: ${{ needs.validate-release-tag.outputs.prerelease == 'true' }}
+
+          files: release-artifacts/*.jar
+
+          overwrite_files: true
+          fail_on_unmatched_files: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,7 +228,6 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
-      fail-fast: false
       matrix: ${{ fromJson(needs.generate-release-matrix.outputs.matrix) }}
 
     steps:
@@ -257,17 +256,7 @@ jobs:
           curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
 
           changelog-file: release-notes.md
-
-          # mc-publish infers the version type from this value:
-          # *-alpha* -> alpha
-          # *-beta*  -> beta
-          # otherwise -> release
-          version: ${{ github.ref_name }}-${{ matrix.mcversion }}
-
-          name: BTETerraRenderer ${{ github.ref_name }} for Minecraft ${{ matrix.mcversion }}
-
-          files: |
-            artifact/*.jar
+          files: artifact/*.jar
 
   publish-github-release:
     needs:
@@ -282,7 +271,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: release-artifacts
-          pattern: '*'
           merge-multiple: true
           repository: ${{ github.repository }}
           run-id: ${{ needs.locate-build-run.outputs.run-id }}
@@ -307,5 +295,4 @@ jobs:
 
           files: release-artifacts/*.jar
 
-          overwrite_files: true
           fail_on_unmatched_files: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+Keep release notes here, newest first.
+Use the release tag as the heading so the release workflow can match it.
+
+## v1.5.0
+
+* Added support for Minecraft 26.2
+* Improved compatibility with other mods through dependency shading and relocation
+* Fixed rendering issues on Minecraft versions before 1.21.6
+* Improved SVG rendering performance
+* Fixed the game sometimes failing to exit cleanly
+
+## v1.04.0
+
+- Added support for Minecraft 1.21.6–26.2
+- Rewrote the **Open Maps Folder** button
+- Switched to [BuildTheEarth/BTETerraRenderer](https://github.com/BuildTheEarth/BTETerraRenderer)

--- a/README.md
+++ b/README.md
@@ -81,3 +81,9 @@ tf2mandeokyi (https://github.com/tf2mandeokyi/BTETerraRenderer). We tried reachi
 different platforms, but received no response. The focus is on fixing bugs, supporting new versions, and performing
 other maintenance work.
 Many thanks to @Amrsatrio for his significant contributions to the new version.
+
+### Releasing
+
+1. Add a matching `## vX.Y.Z` section to `CHANGELOG.md`.
+2. Tag the commit with the same `vX.Y.Z`.
+3. Push the tag to trigger `.github/workflows/release.yml`, which reuses the Gradle workflow artifacts, publishes each version build to Modrinth and CurseForge, and creates one GitHub release with all jars.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx6G -XX:MaxMetaspaceSize=1G -Dfile.encoding=UTF-8
 # Fabric loader version. It's independent against MC versions
 fabricLoomVersion=1.16-SNAPSHOT
 fabricLoaderVersion=0.19.2
-mod_version=1.5.0-alpha.1
+mod_version=1.5.0
 mod_group=com.mndk
 mod_id=bteterrarenderer
 mod_authors=m4ndeokyi, Amrsatrio, Zoriot

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx6G -XX:MaxMetaspaceSize=1G -Dfile.encoding=UTF-8
 # Fabric loader version. It's independent against MC versions
 fabricLoomVersion=1.16-SNAPSHOT
 fabricLoaderVersion=0.19.2
-mod_version=1.04.0
+mod_version=1.5.0-alpha.1
 mod_group=com.mndk
 mod_id=bteterrarenderer
 mod_authors=m4ndeokyi, Amrsatrio, Zoriot


### PR DESCRIPTION
Adds modrinth, curseforge, and github release publishing

Tagged based and currently used with checked in CHANGELOG.md file. Version was changed to 1.5.0 for that, and we now use proper semver (before leading 0 was included which is no semver version).